### PR TITLE
Add option for serving multiple opening databases + refactor

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,7 +12,7 @@ disable=missing-function-docstring,
 max-line-length=140
 
 [BASIC]
-good-names=db,i,c,s,a,b,o,dp,f,v,
+good-names=db,i,c,s,a,b,o,dp,f,v,dt,
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,6 +6,7 @@ disable=missing-function-docstring,
     missing-class-docstring,
     missing-function-docstring,
     too-many-arguments,
+    too-many-locals,
 
 [FORMAT]
 max-line-length=140

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,17 @@
+[MASTER]
+
+[MESSAGES CONTROL]
+disable=missing-function-docstring,
+    missing-module-docstring,
+    missing-class-docstring,
+    missing-function-docstring,
+    too-many-arguments,
+
+[FORMAT]
+max-line-length=140
+
+[BASIC]
+good-names=db,i,c,s,a,b,o,dp,f,v,
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.analysis.typeCheckingMode": "basic"
+}

--- a/TAKexplorer.py
+++ b/TAKexplorer.py
@@ -56,15 +56,10 @@ def main(args):
             elif opt in ('-b', '--black'):
                 player_black = arg
 
-        db = PositionDataBase()
-        db.open(target_file)
-
-        db_extractor.main(db_file, ptn_file, num_plies, num_games, min_rating, player_black, player_white, db.max_id)
-
-        ptn_parser.main(ptn_file, db)
-
-        db.conn.commit()
-        db.close()
+        with PositionDataBase(target_file) as db:
+            db_extractor.main(db_file, ptn_file, num_plies, num_games, min_rating, player_black, player_white, db.max_id)
+            ptn_parser.main(ptn_file, db)
+            db.conn.commit()
 
     elif task == 'explore':
         data_collector.collector_main(argv[0])
@@ -115,9 +110,9 @@ def main(args):
 
         db_extractor.main(db_file, ptn_file, num_plies, num_games, min_rating, player_black, player_white)
 
-        sg = StatisticsGenerator(target_file)
-        ptn_parser.main(ptn_file, sg)
-        sg.print_results()
+        stats_gen = StatisticsGenerator(target_file)
+        ptn_parser.main(ptn_file, stats_gen)
+        stats_gen.print_results()
 
 
 if __name__ == '__main__':

--- a/TAKexplorer.py
+++ b/TAKexplorer.py
@@ -57,9 +57,9 @@ def main(args):
                 player_black = arg
 
         with PositionDataBase(target_file) as db:
-            db_extractor.main(db_file, ptn_file, num_plies, num_games, min_rating, player_black, player_white, db.max_id)
-            ptn_parser.main(ptn_file, db)
-            db.conn.commit()
+            games = db_extractor.extract_ptn(db_file, num_plies, num_games, min_rating, player_black, player_white, db.max_id)
+            ptn_parser.main(games, db)
+            db.commit()
 
     elif task == 'explore':
         data_collector.collector_main(argv[0])
@@ -108,10 +108,10 @@ def main(args):
             elif opt in ('-b', '--black'):
                 player_black = arg
 
-        db_extractor.main(db_file, ptn_file, num_plies, num_games, min_rating, player_black, player_white)
+        games = db_extractor.extract_ptn(db_file, num_plies, num_games, min_rating, player_black, player_white)
 
         stats_gen = StatisticsGenerator(target_file)
-        ptn_parser.main(ptn_file, stats_gen)
+        ptn_parser.main(games, stats_gen)
         stats_gen.print_results()
 
 

--- a/db_extractor.py
+++ b/db_extractor.py
@@ -1,6 +1,6 @@
 import sqlite3
 from typing import Optional
-from xmlrpc.client import DateTime
+from datetime import datetime
 
 BOTLIST = [
     'WilemBot',
@@ -103,11 +103,9 @@ def get_ptn(game) -> str:
     ptn += get_header('playtak_id', game['id'])
 
     # date and time headers
-    dt = str(DateTime((game['date'] / 1000)))
-    dt_d = dt.split('T', maxsplit=1)[0]
-    dt_d = ''+dt_d[6:8]+'.'+dt_d[4:6]+'.'+dt_d[0:4]
-    ptn += get_header('Date', dt_d)
-    ptn += get_header('Time', dt.split('T')[1])
+    dt = datetime.utcfromtimestamp((game['date'] / 1000))
+    ptn += get_header('Date', dt.strftime("%Y.%m.%d"))
+    ptn += get_header('Time', dt.strftime("%H:%M:%S"))
 
     # TODO clock header
     #    ptn += get_header('Clock', get_timer_info(game.timertime, game.timerinc))

--- a/db_extractor.py
+++ b/db_extractor.py
@@ -1,6 +1,6 @@
 import sqlite3
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timedelta
 
 BOTLIST = [
     'WilemBot',
@@ -107,8 +107,13 @@ def get_ptn(game) -> str:
     ptn += get_header('Date', dt.strftime("%Y.%m.%d"))
     ptn += get_header('Time', dt.strftime("%H:%M:%S"))
 
-    # TODO clock header
-    #    ptn += get_header('Clock', get_timer_info(game.timertime, game.timerinc))
+    def format_clock(timertime_seconds: int, timerinc_seconds: int):
+        """Format `minutes:seconds +incrementseconds` e.g. `3:0 +5"""
+        timertime = timedelta(seconds=timertime_seconds)
+        timerinc = timedelta(seconds=timerinc_seconds)
+        return f"{timertime.seconds // 60}:{timertime.seconds % 60} +{timerinc.seconds}"
+
+    ptn += get_header('Clock', format_clock(game['timertime'], game['timerinc']))
 
     ptn += get_moves(game['notation'])
     ptn += '\n\n\n'

--- a/db_extractor.py
+++ b/db_extractor.py
@@ -1,4 +1,5 @@
 import sqlite3
+from typing import Optional
 from xmlrpc.client import DateTime
 
 BOTLIST = [
@@ -83,14 +84,14 @@ def get_moves(notation: str):
 def get_ptn(game) -> str:
     ptn = ''
 
-    wn = 'Anon' if game['date'] < 1461430800000 else game['player_white']
-    bn = 'Anon' if game['date'] < 1461430800000 else game['player_black']
+    white_name = 'Anon' if game['date'] < 1461430800000 else game['player_white']
+    black_name = 'Anon' if game['date'] < 1461430800000 else game['player_black']
 
     ptn += get_header('Site', 'PlayTak.com')
     ptn += get_header('Event', 'Online Play')
 
-    ptn += get_header('Player1', wn)
-    ptn += get_header('Player2', bn)
+    ptn += get_header('Player1', white_name)
+    ptn += get_header('Player2', black_name)
 
     ptn += get_header('Result', game['result'])
     ptn += get_header('Size', game['size'])
@@ -103,7 +104,7 @@ def get_ptn(game) -> str:
 
     # date and time headers
     dt = str(DateTime((game['date'] / 1000)))
-    dt_d = dt.split('T')[0]
+    dt_d = dt.split('T', maxsplit=1)[0]
     dt_d = ''+dt_d[6:8]+'.'+dt_d[4:6]+'.'+dt_d[0:4]
     ptn += get_header('Date', dt_d)
     ptn += get_header('Time', dt.split('T')[1])
@@ -122,8 +123,8 @@ def extract_ptn(
     num_plies: int,
     num_games: int,
     min_rating: int,
-    player_white: str = None,
-    player_black: str = None,
+    player_white: Optional[str] = None,
+    player_black: Optional[str] = None,
     start_id = 0,
     exclude_bots: bool = False,
 ):

--- a/position_db.py
+++ b/position_db.py
@@ -1,5 +1,4 @@
 import os
-
 import sqlite3
 from typing import Optional, Union
 
@@ -11,7 +10,6 @@ from tak import GameState
 class PositionDataBase(PositionProcessor):
 
     def __init__(self, db_file_name: str):
-        print("!!!! INIT")
         assert db_file_name
         self.conn: Optional[sqlite3.Connection] = None
         self.max_id = 0

--- a/position_processor.py
+++ b/position_processor.py
@@ -7,9 +7,27 @@ from tak import GameState
 class PositionProcessor(ABC):
 
     @abstractmethod
-    def add_game(self, size: int, playtak_id: int, white_name: str, black_name: str, ptn: str, result: str, rating_white: int, rating_black: int) -> int:
+    def add_game(
+        self,
+        size: int,
+        playtak_id: int,
+        white_name: str,
+        black_name: str,
+        ptn: str,
+        result: str,
+        rating_white: int,
+        rating_black: int
+    ) -> int:
         pass
 
     @abstractmethod
-    def add_position(self, game_id: int, move, result: str, tps: str, next_tps: Union[str, None], tak: GameState):
+    def add_position(
+        self,
+        game_id: int,
+        move,
+        result: str,
+        tps: str,
+        next_tps: Union[str, None],
+        tak: GameState
+    ):
         pass

--- a/ptn_parser.py
+++ b/ptn_parser.py
@@ -50,7 +50,7 @@ def add_ptn(ptn, dp: PositionProcessor, max_plies=sys.maxsize):
     dp.add_position(game_id, None, result, tak.get_tps(), None, tak)
 
 
-def main(ptn_file, dp: PositionProcessor):
+def main(ptn_file: str, dp: PositionProcessor):
 
     max_plies = 30
 

--- a/ptn_parser.py
+++ b/ptn_parser.py
@@ -2,7 +2,6 @@ import sys
 
 from tqdm import tqdm
 
-from position_db import PositionDataBase
 from position_processor import PositionProcessor
 from tak import GameState
 
@@ -43,10 +42,10 @@ def add_ptn(ptn, dp: PositionProcessor, max_plies=sys.maxsize):
     game_id = dp.add_game(size, playtak_id, white_name, black_name, ptn, result, rating_white, rating_black)
 
     # make all moves
-    for i in range(0, len(all_moves)):
+    for move in all_moves:
         last_tps = tak.get_tps()
-        tak.move(all_moves[i])
-        last_move = all_moves[i]
+        tak.move(move)
+        last_move = move
         dp.add_position(game_id, last_move, result, last_tps, tak.get_tps(), tak)
     dp.add_position(game_id, None, result, tak.get_tps(), None, tak)
 
@@ -57,12 +56,11 @@ def main(ptn_file, dp: PositionProcessor):
 
     ptn = ''
 
-    f = open(ptn_file)
-    count = f.read().count('[Site')
-    f.close()
+    with open(ptn_file, encoding="UTF-8") as f:
+        count = f.read().count('[Site')
 
     with tqdm(total=count, mininterval=10.0, maxinterval=50.0) as progress:
-        with open(ptn_file) as f:
+        with open(ptn_file, encoding="UTF-8") as f:
             line = f.readline()
             ptn += line
             line = f.readline()

--- a/ptn_parser.py
+++ b/ptn_parser.py
@@ -1,4 +1,5 @@
 import sys
+import typing
 
 from tqdm import tqdm
 
@@ -50,24 +51,10 @@ def add_ptn(ptn, dp: PositionProcessor, max_plies=sys.maxsize):
     dp.add_position(game_id, None, result, tak.get_tps(), None, tak)
 
 
-def main(ptn_file: str, dp: PositionProcessor):
+def main(games: typing.Iterable[typing.Tuple[dict, str]], dp: PositionProcessor, max_plies=30):
+    games = list(games)
 
-    max_plies = 30
-
-    ptn = ''
-
-    with open(ptn_file, encoding="UTF-8") as f:
-        count = f.read().count('[Site')
-
-    with tqdm(total=count, mininterval=10.0, maxinterval=50.0) as progress:
-        with open(ptn_file, encoding="UTF-8") as f:
-            line = f.readline()
-            ptn += line
-            line = f.readline()
-            while line:
-                if line.startswith("[Site"):
-                    add_ptn(ptn, dp, max_plies)
-                    progress.update()
-                    ptn = ''
-                ptn += line
-                line = f.readline()
+    with tqdm(total=len(games), mininterval=10.0, maxinterval=50.0) as progress:
+        for (_game, ptn) in games:
+            add_ptn(ptn, dp, max_plies)
+            progress.update()

--- a/server.py
+++ b/server.py
@@ -53,7 +53,7 @@ def import_playtak_games():
     ):
         print("Fetching latest playtak games DB...")
         try:
-            with requests.get(url) as request, open(playtak_games_db,'wb') as output_file:
+            with requests.get(url, timeout=None) as request, open(playtak_games_db,'wb') as output_file:
                 output_file.write(request.content)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             print("Cannot reach playtak server.")
@@ -78,7 +78,7 @@ def import_playtak_games():
         print("building opening table...")
         ptn_parser.main(games, pos_db, max_plies=MAX_PLIES)
 
-        pos_db.conn.commit()
+        pos_db.commit()
 
         print("done! now serving requests")
 

--- a/server.py
+++ b/server.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 
 import os
+from datetime import timedelta
 import time
-
-from flask import Flask, jsonify
-from flask_apscheduler import APScheduler
-import requests
 import sqlite3
 
+import requests
+from flask import Flask, jsonify
+from flask_apscheduler import APScheduler
+
 import symmetry_normalisator
+from symmetry_normalisator import TpsSymmetry
 import db_extractor
 import ptn_parser
 from position_db import PositionDataBase
@@ -27,41 +29,62 @@ scheduler = APScheduler()
 scheduler.init_app(app)
 scheduler.start()
 
+ANALYZED_OPENINGS_DB_FILE = 'data/openings_s6_1200.db'
+MAX_GAME_EXAMPLES = 4
+MAX_SUGGESTED_MOVES = 20
+
+def to_symmetric_tps(tps: str) -> tuple[str, TpsSymmetry]:
+    tps_l = tps.split(' ')
+    tps_l[2] = '1'
+    tps = ' '.join(tps_l)
+    symmetry = symmetry_normalisator.get_tps_orientation(tps)
+    sym_tps = symmetry_normalisator.transform_tps(tps, symmetry)
+    return sym_tps, symmetry
+
+
 # import dayly update of playtak database
 @scheduler.task('cron', id='import_playtak_games', hour='5', misfire_grace_time=900)
 def import_playtak_games():
 
-    db_file = 'data/games_anon.db'
+    playtak_games_db = 'data/games_anon.db'
 
     ptn_file = 'data/games.ptn'
 
     url = 'https://www.playtak.com/games_anon.db'
-    if not os.path.exists(db_file) or (time.time() - os.stat(db_file).st_mtime) > 36000:
-        print("fetching newest playtak DB...")
+    if (
+        not os.path.exists(playtak_games_db)
+        or (time.time() - os.stat(playtak_games_db).st_mtime) > timedelta(hours=10).seconds
+    ):
+        print("Fetching latest playtak games DB...")
         try:
-            r = requests.get(url)
-            with open(db_file,'wb') as output_file:
-                output_file.write(r.content)
-        except:
+            with requests.get(url) as request, open(playtak_games_db,'wb') as output_file:
+                output_file.write(request.content)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
             print("Cannot reach playtak server.")
-            if not os.path.exists(db_file):
+            if not os.path.exists(playtak_games_db):
                 print("no saved games database. exiting.")
-                raise Exception("can't download playtak database")
+                raise Exception("Failed to download playtak games database") from exc # pylint: disable=broad-exception-raised
             print("Using potentially outdated save of games database.")
 
-    db = PositionDataBase()
-    db.open('data/openings_s6_1200.db')
+    with PositionDataBase(ANALYZED_OPENINGS_DB_FILE) as db:
+        print("extracting games...")
+        db_extractor.main(
+            db_file=playtak_games_db,
+            target_file=ptn_file,
+            num_plies=12,
+            num_games=10000,
+            min_rating=1200,
+            player_black=None,
+            player_white=None,
+            start_id=db.max_id
+        )
 
-    print("extracting games...")
-    db_extractor.main(db_file=db_file, target_file=ptn_file, num_plies=12, num_games=10000, min_rating=1200, player_black=None, player_white=None, start_id=db.max_id)
+        print("building opening table...")
+        ptn_parser.main(ptn_file, db)
 
-    print("building opening table...")
-    ptn_parser.main(ptn_file, db)
+        db.conn.commit()
 
-    db.conn.commit()
-
-    print("done! now serving requests")
-    db.close()
+        print("done! now serving requests")
 
 # import games first time
 import_playtak_games()
@@ -76,127 +99,108 @@ def getgame(game_id):
 
     select_game_sql = "SELECT * FROM games WHERE playtak_id=:game_id;"
 
-    db = sqlite3.connect('data/openings_s6_1200.db')
-    db.row_factory = sqlite3.Row
-    cur = db.cursor()
-    cur.execute(select_game_sql, { "game_id": game_id })
+    with sqlite3.connect(ANALYZED_OPENINGS_DB_FILE) as db:
+        db.row_factory = sqlite3.Row
+        cur = db.cursor()
+        cur.execute(select_game_sql, { "game_id": game_id })
 
-    row = dict(cur.fetchone())
-    cur.close()
-    db.close()
+        row = dict(cur.fetchone())
+        cur.close()
 
     response = jsonify(row)
     response.headers.add("Access-Control-Allow-Origin", "*")
     return response
 
-
-
 @app.route('/api/v1/opening/<path:tps>', methods=['GET'])
-def getposition(tps):
+def get_position(tps):
     print(f'requested position with tps: {tps}')
     # we don't care about move number:
-    tps_l = tps.split(' ')
-    tps_l[2] = '1'
-    tps = ' '.join(tps_l)
-    symmetry = symmetry_normalisator.get_tps_orientation(tps)
-    sym_tps = symmetry_normalisator.transform_tps(tps, symmetry)
+    sym_tps, symmetry = to_symmetric_tps(tps)
 
     select_results_sql = "SELECT * FROM positions WHERE tps=:sym_tps;"
 
-    db = sqlite3.connect('data/openings_s6_1200.db')
-    db.row_factory = sqlite3.Row
-    cur = db.cursor()
-    cur.execute(select_results_sql, { 'sym_tps': sym_tps })
+    with sqlite3.connect(ANALYZED_OPENINGS_DB_FILE) as db:
+        db.row_factory = sqlite3.Row
+        cur = db.cursor() # with closing(db.cursor()) as cur:
+        cur.execute(select_results_sql, { 'sym_tps': sym_tps })
 
-    row = cur.fetchone()
-    if row == None:
-        result = {'white': 0, 'black': 0, 'moves': [], 'games': []}
-        response = jsonify(result)
-        response.headers.add("Access-Control-Allow-Origin", "*")
-        return response
+        row = cur.fetchone()
+        if row is None:
+            result = {'white': 0, 'black': 0, 'moves': [], 'games': []}
+            response = jsonify(result)
+            response.headers.add("Access-Control-Allow-Origin", "*")
+            return response
 
-    row = dict(row)
+        row = dict(row)
+        position_moves = row['moves']
+        if position_moves == '':
+            position_moves = []
+        else:
+            position_moves = position_moves.split(';')
 
-    pos_id = row['id']
+        moves_list = list(map(lambda x: x.split(','), position_moves))
+        moves_list.sort(key=lambda x: int(x[2]), reverse=True)
 
-    position_moves = row['moves']
-    if position_moves == '':
-        position_moves = []
-    else:
-        position_moves = position_moves.split(';')
+        result = {}
+        result['white'] = row['wwins']
+        result['black'] = row['bwins']
 
-    moves_list = list(map(lambda x: x.split(','), position_moves))
-    moves_list.sort(key=lambda x: int(x[2]), reverse=True)
+        real_positions = []
+        moves = []
 
-    result = {}
-    result['white'] = row['wwins']
-    result['black'] = row['bwins']
+        for [move, move_id, _game_count] in moves_list:
+            if len(real_positions) >= MAX_SUGGESTED_MOVES:
+                break
 
-    real_positions = []
-    moves = []
+            if move_id in real_positions:
+                continue
+            select_results_sql = "SELECT * FROM positions WHERE id=:move_id;"
 
-    for r in moves_list:
-        if len(real_positions) >= 20:
-            break
+            cur.execute(select_results_sql, { 'move_id': move_id })
+            exe_res = cur.fetchone()
+            if exe_res is None:
+                continue
+            next_row = dict(exe_res)
+            real_positions.append(move_id)
 
-        move = r[0]
-        move_id = r[1]
-        if move_id in real_positions:
-            continue
-        select_results_sql = "SELECT * FROM positions WHERE id=:move_id;"
+            move = symmetry_normalisator.transposed_transform_move(move, symmetry)
 
-        cur.execute(select_results_sql, { 'move_id': move_id })
-        exe_res = cur.fetchone()
-        if exe_res is None:
-            continue
-        next_row = dict(exe_res)
-        real_positions.append(move_id)
+            moves.append({"ptn": move, "white": next_row['wwins'], "black": next_row['bwins']})
 
-        move = symmetry_normalisator.transposed_transform_move(move, symmetry)
-        times_played = next_row['bwins'] + next_row['wwins']
+        result['moves'] = moves
 
-        moves.append({"ptn": move, "white": next_row['wwins'], "black": next_row['bwins']})
+        # get top games
+        select_games_sql = """
+                SELECT games.id, games.playtak_id, games.white, games.black, games.result, games.rating_white, games.rating_black,
+                    game_position_xref.game_id, game_position_xref.position_id,
+                    positions.id, positions.tps, (games.rating_white+games.rating_black)/2 AS avg_rating
+                FROM game_position_xref, games, positions
+                WHERE game_position_xref.position_id=positions.id
+                    AND games.id = game_position_xref.game_id
+                    AND positions.tps = :sym_tps
+                ORDER BY AVG_rating DESC
+                LIMIT :limit;"""
+        cur.execute(select_games_sql, { 'sym_tps': sym_tps, 'limit': MAX_GAME_EXAMPLES })
+        game_examples = list(map(dict, cur.fetchall()))
 
-    result['moves'] = moves
+        result['games'] = []
 
-    # get top games
-    select_games_sql = """
-            SELECT games.id, games.playtak_id, games.white, games.black, games.result, games.rating_white, games.rating_black,
-                game_position_xref.game_id, game_position_xref.position_id,
-                positions.id, positions.tps, (games.rating_white+games.rating_black)/2 AS avg_rating
-            FROM game_position_xref, games, positions
-            WHERE game_position_xref.position_id=positions.id
-                AND games.id = game_position_xref.game_id
-                AND positions.tps = :sym_tps
-            ORDER BY AVG_rating DESC;"""
-    cur.execute(select_games_sql, { 'sym_tps': sym_tps })
-    row = cur.fetchall()
+        for game in game_examples:
+            print("game", game)
+            result['games'].append({
+                'playtak_id': game['playtak_id'],
+                'result': game['result'],
+                'white': {
+                    'name': game['white'],
+                    'rating': game['rating_white']
+                    },
+                'black': {
+                    'name': game['black'],
+                    'rating': game['rating_black']
+                    }
+                })
 
-    all_games = []
-
-    for r in row:
-        all_games.append(dict(r))
-
-    all_games = all_games[0:min(4, len(all_games))]
-
-    result['games'] = []
-
-    for game in all_games:
-        result['games'].append({
-            'playtak_id': game['playtak_id'],
-            'result': game['result'],
-            'white': {
-                'name': game['white'],
-                'rating': game['rating_white']
-                },
-            'black': {
-                'name': game['black'],
-                'rating': game['rating_black']
-                }
-            })
-
-    cur.close()
-    db.close()
+        cur.close()
 
     response = jsonify(result)
     response.headers.add("Access-Control-Allow-Origin", "*")

--- a/server.py
+++ b/server.py
@@ -15,11 +15,9 @@ import db_extractor
 import ptn_parser
 from position_db import PositionDataBase
 
-try:
-    print("creating data directory...")
-    os.mkdir("data")
-except FileExistsError as e:
-    print("data directory already exists")
+ANALYZED_OPENINGS_DB_FILE = 'data/openings_s6_1200.db'
+MAX_GAME_EXAMPLES = 4
+MAX_SUGGESTED_MOVES = 20
 
 app = Flask(__name__)
 app.config['JSON_SORT_KEYS'] = False
@@ -28,10 +26,6 @@ app.config['SCHEDULER_API_ENABLED'] = True
 scheduler = APScheduler()
 scheduler.init_app(app)
 scheduler.start()
-
-ANALYZED_OPENINGS_DB_FILE = 'data/openings_s6_1200.db'
-MAX_GAME_EXAMPLES = 4
-MAX_SUGGESTED_MOVES = 20
 
 def to_symmetric_tps(tps: str) -> tuple[str, TpsSymmetry]:
     tps_l = tps.split(' ')
@@ -85,9 +79,6 @@ def import_playtak_games():
         db.conn.commit()
 
         print("done! now serving requests")
-
-# import games first time
-import_playtak_games()
 
 @app.route('/')
 def hello():
@@ -186,7 +177,6 @@ def get_position(tps):
         result['games'] = []
 
         for game in game_examples:
-            print("game", game)
             result['games'].append({
                 'playtak_id': game['playtak_id'],
                 'result': game['result'],
@@ -205,3 +195,13 @@ def get_position(tps):
     response = jsonify(result)
     response.headers.add("Access-Control-Allow-Origin", "*")
     return response
+
+
+try:
+    print("creating data directory...")
+    os.mkdir("data")
+except FileExistsError as e:
+    print("data directory already exists")
+
+# import games first time
+import_playtak_games()

--- a/statistics_generator.py
+++ b/statistics_generator.py
@@ -84,21 +84,20 @@ class StatisticsGenerator(PositionProcessor):
         self.all_games[self.result] += 1
 
     def print_results(self):
-        f = open(self.target_file, 'w')
-        json_obj = {
-            'all_games': self.all_games,
-            'w_hard_cap_18': self.w_hard_cap_18,
-            'b_hard_cap_18': self.b_hard_cap_18,
-            'w_hard_cap_24': self.w_hard_cap_24,
-            'b_hard_cap_24': self.b_hard_cap_24,
-            'w_cap_12': self.w_cap_12,
-            'b_cap_12': self.b_cap_12,
-            'w_cap_18': self.w_cap_18,
-            'b_cap_18': self.b_cap_18,
-            'w_cap_24': self.w_cap_24,
-            'b_cap_24': self.b_cap_24,
-        }
-        for v in json_obj.values():
-            v['white_win_percent'] = int(float(v['white']/(v['white']+v['black']))*100)
-        json.dump(json_obj, f, indent=4)
-        f.close()
+        with open(self.target_file, 'w', encoding="UTF-8") as f:
+            json_obj = {
+                'all_games': self.all_games,
+                'w_hard_cap_18': self.w_hard_cap_18,
+                'b_hard_cap_18': self.b_hard_cap_18,
+                'w_hard_cap_24': self.w_hard_cap_24,
+                'b_hard_cap_24': self.b_hard_cap_24,
+                'w_cap_12': self.w_cap_12,
+                'b_cap_12': self.b_cap_12,
+                'w_cap_18': self.w_cap_18,
+                'b_cap_18': self.b_cap_18,
+                'w_cap_24': self.w_cap_24,
+                'b_cap_24': self.b_cap_24,
+            }
+            for v in json_obj.values():
+                v['white_win_percent'] = int(float(v['white']/(v['white']+v['black']))*100)
+            json.dump(json_obj, f, indent=4)

--- a/statistics_generator.py
+++ b/statistics_generator.py
@@ -1,5 +1,5 @@
 import json
-from typing import Union
+from typing import Literal, Optional, Union
 
 from position_processor import PositionProcessor
 from tak import GameState
@@ -8,8 +8,8 @@ from tak import GameState
 class StatisticsGenerator(PositionProcessor):
     def __init__(self, target_file: str):
         self.target_file = target_file
-        self.ply = None
-        self.result = None
+        self.ply: int = 0
+        self.result: Optional[Literal['draw', 'white', 'black']] = None
         self.w_has_hard_cap = False
         self.b_has_hard_cap = False
         self.all_games = {'white': 0, 'black': 0, 'draw': 0}

--- a/symmetry_normalisator.py
+++ b/symmetry_normalisator.py
@@ -1,4 +1,5 @@
 import sys
+from typing import NewType
 
 # only works with size 6!!
 
@@ -23,12 +24,12 @@ def rotate_tps(tps: str) -> str:
     tps = tps.replace('x3', 'x,x,x')
     tps = tps.replace('x2', 'x,x')
 
-    spl = tps.split('/')
+    splits = tps.split('/')
 
     board = []
 
-    for i in range(0, len(spl)):
-        board.append(spl[i].split(','))
+    for split in splits:
+        board.append(split.split(','))
 
     board = rotate_mat(board)
 
@@ -42,8 +43,9 @@ def rotate_tps(tps: str) -> str:
 
     return tps
 
+TpsSymmetry = NewType("TpsSymmetry", int)
 
-def get_tps_orientation(tps: str) -> int:
+def get_tps_orientation(tps: str) -> TpsSymmetry:
     # ignore ending (current player)
     tps = tps[:-4]
 
@@ -76,16 +78,16 @@ def transform_tps(tps: str, orientation: int) -> str:
 
     if orientation > 3:
         tps = flip_tps(tps)
-        for i in range(4, orientation):
+        for _ in range(4, orientation):
             tps = rotate_tps(tps)
     else:
-        for i in range(0, orientation):
+        for _ in range(0, orientation):
             tps = rotate_tps(tps)
 
     return tps + ending
 
 
-def transposed_transform_tps(tps: str, orientation: int) -> str:
+def transposed_transform_tps(tps: str, orientation: TpsSymmetry) -> str:
     # TODO
     return tps
 
@@ -136,15 +138,15 @@ def transform_move(move: str, orientation: int) -> str:
     if orientation >= 4:
         move = swapchars(move, '+', '-')
         move = swapsquare(move)
-    for i in range(0, orientation):
+    for _ in range(0, orientation):
         move = rotate_move(move)
     test_transpose = transposed_transform_move(move, orientation)
     assert test_transpose == orig
     return move
 
 
-def transposed_transform_move(move: str, orientation: int) -> str:
-    for i in range(orientation, 4 if orientation >= 4 else 0, -1):
+def transposed_transform_move(move: str, orientation: TpsSymmetry) -> str:
+    for _ in range(orientation, 4 if orientation >= 4 else 0, -1):
         move = rotate_move(move)
         move = rotate_move(move)
         move = rotate_move(move)

--- a/symmetry_normalisator.py
+++ b/symmetry_normalisator.py
@@ -68,7 +68,7 @@ def get_tps_orientation(tps: str) -> TpsSymmetry:
         if rot_tps < best_tps:
             o = i
             best_tps = rot_tps
-    return o
+    return TpsSymmetry(o)
 
 
 def transform_tps(tps: str, orientation: int) -> str:
@@ -127,13 +127,13 @@ def rotate_move(move: str) -> str:
     sys.exit(2)
 
 
-def swapsquare(move):
+def swapsquare(move: str):
     for i in range(0, len(move) - 1):
         if move[i].islower():
             return move[:i+1] + swapint(move[i + 1]) + move[i + 2:]
 
 
-def transform_move(move: str, orientation: int) -> str:
+def transform_move(move: str, orientation: TpsSymmetry) -> str:
     orig = move
     if orientation >= 4:
         move = swapchars(move, '+', '-')


### PR DESCRIPTION
# Changes / Improvements
## developer experience
- Some refactoring to make the code slightly easier to use
- enabled type checking in vs code and thus added more type hints
- added .pylintrc to configure linting 

## Features
- added OpeningDbConfig class to allow setting up multiple databases with different settings like ELO and whether to include bot games. 
   - `api/v1/openings/<databaseId>/<tps>` 
   - `api/v1/databases`
- database import & update
  - initial import on startup is now done asynchronously, so the server should already be able to serve some requests (though the DB may ne be fully populated yet or actually be locked by the updating process)
  - rescheduled the download and import of the new playtak games database to `17:10` as the new DB is usually released around `17:00 UTC` (I've also changed the server's timezone to `UTC`)

# Other notes
When running with `hopper` for auto reloads I noticed this warning. I went back to 7568f71 but the warning persisted - so it's not a new thing I introduced. Might still be worth investigating. Might also just be something flask/scheduler keeps in memory
```
/opt/homebrew/Cellar/python@3.9/3.9.7_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/resource_tracker.py:216: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```